### PR TITLE
Feat/update issuance v0.95

### DIFF
--- a/MultipazCodelab/Holder/composeApp/build.gradle.kts
+++ b/MultipazCodelab/Holder/composeApp/build.gradle.kts
@@ -52,7 +52,7 @@ kotlin {
             implementation(libs.kotlinx.datetime)
             implementation(libs.multipaz)
             implementation(libs.multipaz.doctypes)
-            implementation(libs.multipaz.models)
+            implementation(libs.multipaz.dcapi)
             implementation(libs.multipaz.compose)
             implementation(libs.ktor.client.core)
             // CIO for JVM/Android; Darwin engine for iOS in iosMain

--- a/MultipazCodelab/Holder/composeApp/src/androidMain/kotlin/org/multipaz/samples/wallet/cmp/CredmanActivity.kt
+++ b/MultipazCodelab/Holder/composeApp/src/androidMain/kotlin/org/multipaz/samples/wallet/cmp/CredmanActivity.kt
@@ -6,7 +6,7 @@ import coil3.ImageLoader
 import org.koin.android.ext.android.inject
 import org.multipaz.compose.digitalcredentials.CredentialManagerPresentmentActivity
 import org.multipaz.documenttype.DocumentTypeRepository
-import org.multipaz.models.presentment.PresentmentSource
+import org.multipaz.presentment.model.PresentmentSource
 import org.multipaz.prompt.PromptModel
 import org.multipaz.samples.wallet.cmp.util.Constants.APP_NAME
 import org.multipaz.samples.wallet.cmp.util.Constants.appIcon

--- a/MultipazCodelab/Holder/composeApp/src/androidMain/kotlin/org/multipaz/samples/wallet/cmp/MainActivity.kt
+++ b/MultipazCodelab/Holder/composeApp/src/androidMain/kotlin/org/multipaz/samples/wallet/cmp/MainActivity.kt
@@ -12,7 +12,7 @@ import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.launch
 import org.koin.android.ext.android.inject
 import org.multipaz.context.initializeApplication
-import org.multipaz.models.provisioning.ProvisioningModel
+import org.multipaz.provisioning.ProvisioningModel
 import org.multipaz.samples.wallet.cmp.util.ProvisioningSupport
 import org.multipaz.util.Logger
 

--- a/MultipazCodelab/Holder/composeApp/src/androidMain/kotlin/org/multipaz/samples/wallet/cmp/NfcActivity.kt
+++ b/MultipazCodelab/Holder/composeApp/src/androidMain/kotlin/org/multipaz/samples/wallet/cmp/NfcActivity.kt
@@ -6,7 +6,7 @@ import coil3.ImageLoader
 import org.koin.android.ext.android.inject
 import org.multipaz.compose.mdoc.MdocNfcPresentmentActivity
 import org.multipaz.documenttype.DocumentTypeRepository
-import org.multipaz.models.presentment.PresentmentSource
+import org.multipaz.presentment.model.PresentmentSource
 import org.multipaz.prompt.PromptModel
 import org.multipaz.samples.wallet.cmp.util.Constants.APP_NAME
 import org.multipaz.samples.wallet.cmp.util.Constants.appIcon

--- a/MultipazCodelab/Holder/composeApp/src/commonMain/kotlin/org/multipaz/samples/wallet/cmp/UtopiaSampleApp.kt
+++ b/MultipazCodelab/Holder/composeApp/src/commonMain/kotlin/org/multipaz/samples/wallet/cmp/UtopiaSampleApp.kt
@@ -9,7 +9,7 @@ import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import kotlinx.coroutines.channels.Channel
 import org.koin.compose.koinInject
-import org.multipaz.models.provisioning.ProvisioningModel
+import org.multipaz.provisioning.ProvisioningModel
 import org.multipaz.samples.wallet.cmp.ui.HomeScreen
 import org.multipaz.samples.wallet.cmp.ui.ProvisioningTestScreen
 import org.multipaz.samples.wallet.cmp.util.ProvisioningSupport

--- a/MultipazCodelab/Holder/composeApp/src/commonMain/kotlin/org/multipaz/samples/wallet/cmp/di/MultipazModule.kt
+++ b/MultipazCodelab/Holder/composeApp/src/commonMain/kotlin/org/multipaz/samples/wallet/cmp/di/MultipazModule.kt
@@ -5,17 +5,18 @@ import kotlinx.coroutines.runBlocking
 import kotlinx.io.bytestring.ByteString
 import org.koin.dsl.module
 import org.multipaz.crypto.X509Cert
+import org.multipaz.digitalcredentials.Default
+import org.multipaz.digitalcredentials.DigitalCredentials
 import org.multipaz.document.DocumentMetadata
 import org.multipaz.document.DocumentStore
 import org.multipaz.document.buildDocumentStore
 import org.multipaz.documenttype.DocumentTypeRepository
 import org.multipaz.documenttype.knowntypes.DrivingLicense
-import org.multipaz.documenttype.knowntypes.LoyaltyID
-import org.multipaz.models.digitalcredentials.DigitalCredentials
-import org.multipaz.models.presentment.PresentmentModel
-import org.multipaz.models.presentment.PresentmentSource
-import org.multipaz.models.presentment.SimplePresentmentSource
-import org.multipaz.models.provisioning.ProvisioningModel
+import org.multipaz.documenttype.knowntypes.Loyalty
+import org.multipaz.presentment.model.PresentmentModel
+import org.multipaz.presentment.model.PresentmentSource
+import org.multipaz.presentment.model.SimplePresentmentSource
+import org.multipaz.provisioning.ProvisioningModel
 import org.multipaz.prompt.PromptModel
 import org.multipaz.samples.wallet.cmp.util.ProvisioningSupport
 import org.multipaz.samples.wallet.cmp.util.TestAppUtils
@@ -42,7 +43,7 @@ val multipazModule = module {
     single<DocumentTypeRepository> {
         DocumentTypeRepository().apply {
             addDocumentType(DrivingLicense.getDocumentType())
-            addDocumentType(LoyaltyID.getDocumentType())
+            addDocumentType(Loyalty.getDocumentType())
         }
     }
     single<DocumentStore> {

--- a/MultipazCodelab/Holder/composeApp/src/commonMain/kotlin/org/multipaz/samples/wallet/cmp/ui/AccountScreen.kt
+++ b/MultipazCodelab/Holder/composeApp/src/commonMain/kotlin/org/multipaz/samples/wallet/cmp/ui/AccountScreen.kt
@@ -45,8 +45,8 @@ import org.multipaz.compose.qrcode.generateQrCode
 import org.multipaz.documenttype.DocumentTypeRepository
 import org.multipaz.mdoc.connectionmethod.MdocConnectionMethodBle
 import org.multipaz.mdoc.transport.MdocTransportOptions
-import org.multipaz.models.presentment.PresentmentModel
-import org.multipaz.models.presentment.PresentmentSource
+import org.multipaz.presentment.model.PresentmentModel
+import org.multipaz.presentment.model.PresentmentSource
 import org.multipaz.prompt.PromptModel
 import org.multipaz.samples.wallet.cmp.util.Constants.APP_NAME
 import org.multipaz.samples.wallet.cmp.util.Constants.appIcon

--- a/MultipazCodelab/Holder/composeApp/src/commonMain/kotlin/org/multipaz/samples/wallet/cmp/ui/ProvisioningTestScreen.kt
+++ b/MultipazCodelab/Holder/composeApp/src/commonMain/kotlin/org/multipaz/samples/wallet/cmp/ui/ProvisioningTestScreen.kt
@@ -16,7 +16,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import org.multipaz.models.provisioning.ProvisioningModel
+import org.multipaz.provisioning.ProvisioningModel
 import org.multipaz.util.Logger
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Spacer

--- a/MultipazCodelab/Holder/composeApp/src/commonMain/kotlin/org/multipaz/samples/wallet/cmp/util/AppSettingsModel.kt
+++ b/MultipazCodelab/Holder/composeApp/src/commonMain/kotlin/org/multipaz/samples/wallet/cmp/util/AppSettingsModel.kt
@@ -14,7 +14,8 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.io.bytestring.ByteString
 import org.multipaz.cbor.buildCborArray
-import org.multipaz.models.digitalcredentials.DigitalCredentials
+import org.multipaz.digitalcredentials.Default
+import org.multipaz.digitalcredentials.DigitalCredentials
 import kotlin.Boolean
 import kotlin.time.ExperimentalTime
 

--- a/MultipazCodelab/Holder/composeApp/src/iosMain/kotlin/org/multipaz/samples/wallet/cmp/MainViewController.kt
+++ b/MultipazCodelab/Holder/composeApp/src/iosMain/kotlin/org/multipaz/samples/wallet/cmp/MainViewController.kt
@@ -16,9 +16,9 @@ import kotlinx.coroutines.channels.Channel
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.get
 import org.multipaz.document.DocumentStore
-import org.multipaz.models.presentment.PresentmentModel
-import org.multipaz.models.presentment.PresentmentSource
-import org.multipaz.models.provisioning.ProvisioningModel
+import org.multipaz.presentment.model.PresentmentModel
+import org.multipaz.presentment.model.PresentmentSource
+import org.multipaz.provisioning.ProvisioningModel
 import org.multipaz.samples.wallet.cmp.di.initKoin
 import org.multipaz.samples.wallet.cmp.util.ProvisioningSupport
 import org.multipaz.trustmanagement.TrustManager

--- a/MultipazCodelab/Holder/gradle/libs.versions.toml
+++ b/MultipazCodelab/Holder/gradle/libs.versions.toml
@@ -18,7 +18,7 @@ kotlinx-io = "0.4.0"
 kotlinx-datetime = "0.6.0"
 kotlinx-serialization = "1.7.3"
 # Align Multipaz with Kotlin 2.2.0 (same as identity-credential root)
-multipaz = "0.94.0"
+multipaz = "0.95.0"
 ktor = "2.3.13"
 androidx-sqlite = "2.5.2"
 coil = "3.3.0"
@@ -47,8 +47,8 @@ kotlinx-datetime = { group = "org.jetbrains.kotlinx", name = "kotlinx-datetime",
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization" }
 multipaz = { group = "org.multipaz", name = "multipaz", version.ref = "multipaz" }
 multipaz-doctypes = { group = "org.multipaz", name = "multipaz-doctypes", version.ref = "multipaz" }
-multipaz-models = { group = "org.multipaz", name = "multipaz-models", version.ref = "multipaz" }
 multipaz-compose = { group = "org.multipaz", name = "multipaz-compose", version.ref = "multipaz" }
+multipaz-dcapi = { group = "org.multipaz", name = "multipaz-dcapi", version.ref = "multipaz" }
 ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
 ktor-client-java = { module = "io.ktor:ktor-client-java", version.ref = "ktor" }
 ktor-client-cio = { module = "io.ktor:ktor-client-cio", version.ref = "ktor" }


### PR DESCRIPTION
This pull request updates the Multipaz sample wallet app to use new package structures and APIs following a Multipaz library upgrade, and introduces improvements to provisioning and digital credential handling. The main themes are dependency updates, migration to new package namespaces, and enhancements for standards compliance and digital credential management.

**Dependency and Package Updates:**

* Upgraded the Multipaz library version from `0.94.0` to `0.95.0` and replaced the dependency on `multipaz-models` with `multipaz-dcapi` in `build.gradle.kts` and `libs.versions.toml`. [[1]](diffhunk://#diff-b87bf2b251373178f7de06f9409ec2aa9fe57c7e7ac5f390fd5c3e1c60dcc22aL21-R21) [[2]](diffhunk://#diff-bbf065f07e7518d79bd5774211412be41102c50dae5d29f45979ecdc489eae7cL55-R55) [[3]](diffhunk://#diff-b87bf2b251373178f7de06f9409ec2aa9fe57c7e7ac5f390fd5c3e1c60dcc22aL50-R51)
* Updated all imports throughout the codebase to use the new package paths for `provisioning`, `presentment`, and `digitalcredentials` classes, reflecting the Multipaz package reorganization. [[1]](diffhunk://#diff-3ec5b59eb717ff79842c60194b68096cd698bde6c4fb332ca8affa99dcbb839eR8-R19) [[2]](diffhunk://#diff-533cd45a344a8a900a323f4745c6464da01ee0199d34d5d59ae68666e7014f53L12-R12) [[3]](diffhunk://#diff-668e2cf2da694ce876c91a48800392997aa63330ba44612d09982752794ab70bL15-R15) [[4]](diffhunk://#diff-d15f631f23ae2fbb17e916076542a4152e58b910c18394df343f1eb5f6538bd6L19-R21) [[5]](diffhunk://#diff-d8b564b4492104cc0d051c48177766418ddb5fffb707afc45ee039d1535da4c9L48-R49) [[6]](diffhunk://#diff-42543053c5042cfcf25052e747aa25e7c43e9642bf9310dda5d03fb00373c85bL19-R19) [[7]](diffhunk://#diff-0c03367209f0eaa8c77bf61a24d98aa61e7cbeecd6fab3efb9c7fe3d43ead8d6L17-R18) [[8]](diffhunk://#diff-64e836000bcb4ec3d8cbe13e07564f67b8fa03b518356e5cbdfab639388dfa88L9-R9) [[9]](diffhunk://#diff-b6248d987290e029d10e50872ddf04a7079bc252f324e0fbf63a50dca66bacb0L9-R9)

**Digital Credentials and Document Types:**

* Replaced the use of `LoyaltyID` with `Loyalty` for document type registration, and added logic to automatically start exporting credentials via `DigitalCredentials.Default` if available. [[1]](diffhunk://#diff-3ec5b59eb717ff79842c60194b68096cd698bde6c4fb332ca8affa99dcbb839eL44-R46) [[2]](diffhunk://#diff-3ec5b59eb717ff79842c60194b68096cd698bde6c4fb332ca8affa99dcbb839eR144-R151) [[3]](diffhunk://#diff-3ec5b59eb717ff79842c60194b68096cd698bde6c4fb332ca8affa99dcbb839eR164)

**Provisioning and Standards Compliance:**

* Refactored `ProvisioningSupport` to improve JWT client assertion and key attestation generation: changed method parameters for clarity, fixed the JWT header and payload fields to match OpenID4VCI and RFC 7523 requirements, and improved certificate encoding handling. [[1]](diffhunk://#diff-57e31d6dbee5197ff8fbb61cfdab64e9400b39582fde7b270a50060beaf9761dR122-L140) [[2]](diffhunk://#diff-57e31d6dbee5197ff8fbb61cfdab64e9400b39582fde7b270a50060beaf9761dL149-R141) [[3]](diffhunk://#diff-57e31d6dbee5197ff8fbb61cfdab64e9400b39582fde7b270a50060beaf9761dL173-R165) [[4]](diffhunk://#diff-57e31d6dbee5197ff8fbb61cfdab64e9400b39582fde7b270a50060beaf9761dL213-R217)

**Fix Exporting credentials:**

* We begin exporting credentials from the moment the PresentmentSource is initialized.
Prof: https://drive.google.com/file/d/1sBUnnc02FpisgYXUCgdMDGKUKbCP0NXv/view?usp=share_link
