### PR TITLE
Integrated  Document Carousel into wallet

### DIFF
--- a/ComposeWallet/composeApp/src/commonMain/kotlin/org/multipaz/samples/wallet/cmp/Route.kt
+++ b/ComposeWallet/composeApp/src/commonMain/kotlin/org/multipaz/samples/wallet/cmp/Route.kt
@@ -1,0 +1,14 @@
+package org.multipaz.samples.wallet.cmp
+
+import org.multipaz.compose.document.DocumentInfo
+
+sealed interface AppRoute {
+    data object Wallet : AppRoute
+    data object Provisioning : AppRoute
+}
+
+sealed interface WalletRoute {
+    data object Wallet : WalletRoute
+    data class WalletDetails(val documentInfo: DocumentInfo) : WalletRoute
+}
+

--- a/ComposeWallet/composeApp/src/commonMain/kotlin/org/multipaz/samples/wallet/cmp/navhost/AppNavHost.kt
+++ b/ComposeWallet/composeApp/src/commonMain/kotlin/org/multipaz/samples/wallet/cmp/navhost/AppNavHost.kt
@@ -1,0 +1,47 @@
+package org.multipaz.samples.wallet.cmp.navhost
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import coil3.ImageLoader
+import org.multipaz.provisioning.ProvisioningModel
+import org.multipaz.samples.wallet.cmp.App
+import org.multipaz.samples.wallet.cmp.AppRoute
+import org.multipaz.samples.wallet.cmp.ui.ProvisioningScreen
+
+@Composable
+fun AppNavHost(
+    app: App,
+    imageLoader: ImageLoader,
+) {
+    var appRoute by remember { mutableStateOf<AppRoute>(AppRoute.Wallet) }
+    val provisioningState = app.provisioningModel.state.collectAsState().value
+
+    LaunchedEffect(provisioningState) {
+        val provisioningActive =
+            provisioningState != ProvisioningModel.Idle &&
+                    provisioningState != ProvisioningModel.CredentialsIssued
+
+        appRoute = if (provisioningActive) AppRoute.Provisioning else AppRoute.Wallet
+    }
+
+    when (appRoute) {
+        AppRoute.Wallet -> WalletNavHost(
+            documentModel = app.documentModel,
+            presentmentModel = app.presentmentModel,
+            presentmentSource = app.presentmentSource,
+            documentTypeRepository = app.documentTypeRepository,
+            imageLoader = imageLoader
+        )
+
+        AppRoute.Provisioning -> ProvisioningScreen(
+            provisioningModel = app.provisioningModel,
+            provisioningSupport = app.provisioningSupport,
+            onCancel = { app.provisioningModel.cancel() }
+        )
+    }
+}

--- a/ComposeWallet/composeApp/src/commonMain/kotlin/org/multipaz/samples/wallet/cmp/navhost/WalletNavHost.kt
+++ b/ComposeWallet/composeApp/src/commonMain/kotlin/org/multipaz/samples/wallet/cmp/navhost/WalletNavHost.kt
@@ -1,0 +1,47 @@
+package org.multipaz.samples.wallet.cmp.navhost
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import coil3.ImageLoader
+import org.multipaz.compose.document.DocumentModel
+import org.multipaz.documenttype.DocumentTypeRepository
+import org.multipaz.presentment.model.PresentmentModel
+import org.multipaz.presentment.model.PresentmentSource
+import org.multipaz.samples.wallet.cmp.WalletRoute
+import org.multipaz.samples.wallet.cmp.ui.WalletDetailScreen
+import org.multipaz.samples.wallet.cmp.ui.WalletScreen
+
+@Composable
+fun WalletNavHost(
+    documentModel: DocumentModel,
+    presentmentModel: PresentmentModel,
+    presentmentSource: PresentmentSource,
+    documentTypeRepository: DocumentTypeRepository,
+    imageLoader: ImageLoader,
+) {
+    val navState = remember { mutableStateOf<WalletRoute>(WalletRoute.Wallet) }
+
+    when (val route = navState.value) {
+        WalletRoute.Wallet -> {
+            WalletScreen(
+                documentModel = documentModel,
+                onDocumentSelected = { documentInfo ->
+                    navState.value = WalletRoute.WalletDetails(documentInfo)
+                }
+            )
+        }
+
+        is WalletRoute.WalletDetails -> {
+            WalletDetailScreen(
+                documentInfo = route.documentInfo,
+                documentModel = documentModel,
+                presentmentModel = presentmentModel,
+                presentmentSource = presentmentSource,
+                documentTypeRepository = documentTypeRepository,
+                imageLoader = imageLoader,
+                onBack = { navState.value = WalletRoute.Wallet }
+            )
+        }
+    }
+}

--- a/ComposeWallet/composeApp/src/commonMain/kotlin/org/multipaz/samples/wallet/cmp/ui/ProvisioningScreen.kt
+++ b/ComposeWallet/composeApp/src/commonMain/kotlin/org/multipaz/samples/wallet/cmp/ui/ProvisioningScreen.kt
@@ -1,0 +1,42 @@
+package org.multipaz.samples.wallet.cmp.ui
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import org.multipaz.compose.provisioning.Provisioning
+import org.multipaz.provisioning.ProvisioningModel
+import org.multipaz.samples.wallet.cmp.ProvisioningSupport
+
+@Composable
+fun ProvisioningScreen(
+    provisioningModel: ProvisioningModel,
+    provisioningSupport: ProvisioningSupport,
+    onCancel: () -> Unit,
+) {
+    Column(
+        modifier = Modifier.fillMaxSize(),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Provisioning(
+            provisioningModel = provisioningModel,
+            waitForRedirectLinkInvocation = { state ->
+                provisioningSupport.waitForAppLinkInvocation(state)
+            }
+        )
+
+        Spacer(Modifier.padding(12.dp))
+
+        Button(onClick = onCancel) {
+            Text("Cancel Provisioning")
+        }
+    }
+}

--- a/ComposeWallet/composeApp/src/commonMain/kotlin/org/multipaz/samples/wallet/cmp/ui/QrPresentmentDialog.kt
+++ b/ComposeWallet/composeApp/src/commonMain/kotlin/org/multipaz/samples/wallet/cmp/ui/QrPresentmentDialog.kt
@@ -1,0 +1,163 @@
+package org.multipaz.samples.wallet.cmp.ui
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import coil3.ImageLoader
+import mpzcmpwallet.composeapp.generated.resources.Res
+import mpzcmpwallet.composeapp.generated.resources.compose_multiplatform
+import org.jetbrains.compose.resources.painterResource
+import org.multipaz.compose.presentment.MdocProximityQrPresentment
+import org.multipaz.compose.presentment.MdocProximityQrSettings
+import org.multipaz.compose.qrcode.generateQrCode
+import org.multipaz.documenttype.DocumentTypeRepository
+import org.multipaz.mdoc.connectionmethod.MdocConnectionMethodBle
+import org.multipaz.mdoc.transport.MdocTransportOptions
+import org.multipaz.presentment.model.PresentmentModel
+import org.multipaz.presentment.model.PresentmentSource
+import org.multipaz.samples.wallet.cmp.App
+import org.multipaz.util.UUID
+
+@Composable
+fun QrPresentmentDialog(
+    presentmentModel: PresentmentModel,
+    presentmentSource: PresentmentSource,
+    documentTypeRepository: DocumentTypeRepository,
+    imageLoader: ImageLoader,
+    onDismiss: () -> Unit,
+) {
+    Dialog(
+        onDismissRequest = {
+            presentmentModel.reset()
+            onDismiss()
+        },
+        properties = DialogProperties(
+            usePlatformDefaultWidth = false
+        )
+    ) {
+        Surface(
+            shape = MaterialTheme.shapes.large,
+            tonalElevation = 6.dp,
+            modifier = Modifier
+                .fillMaxWidth(0.9f)
+                .padding(vertical = 24.dp)
+        ) {
+            MdocProximityQrPresentment(
+                appName = "MpzCmpWallet",
+                appIconPainter = painterResource(Res.drawable.compose_multiplatform),
+                presentmentModel = presentmentModel,
+                presentmentSource = presentmentSource,
+                promptModel = App.promptModel,
+                documentTypeRepository = documentTypeRepository,
+                imageLoader = imageLoader,
+                allowMultipleRequests = false,
+                showQrButton = { onQrButtonClicked -> ShowQrButton(onQrButtonClicked) },
+                showQrCode = { uri ->
+                    ShowQrCode(
+                        uri = uri,
+                        onDismiss = {
+                            presentmentModel.reset()
+                            onDismiss()
+                        }
+                    )
+                }
+
+            )
+        }
+    }
+}
+
+
+@Composable
+private fun ShowQrButton(
+    onQrButtonClicked: (settings: MdocProximityQrSettings) -> Unit
+) {
+    Column(
+        modifier = Modifier.padding(16.dp),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Text(
+            text = "Present mDL",
+            style = MaterialTheme.typography.titleMedium
+        )
+        Spacer(Modifier.height(16.dp))
+        Button(
+            onClick = {
+                val connectionMethods = listOf(
+                    MdocConnectionMethodBle(
+                        supportsPeripheralServerMode = false,
+                        supportsCentralClientMode = true,
+                        peripheralServerModeUuid = null,
+                        centralClientModeUuid = UUID.randomUUID(),
+                    )
+                )
+                onQrButtonClicked(
+                    MdocProximityQrSettings(
+                        availableConnectionMethods = connectionMethods,
+                        createTransportOptions = MdocTransportOptions(
+                            bleUseL2CAP = true
+                        )
+                    )
+                )
+            }
+        ) {
+            Text("Show QR code")
+        }
+    }
+}
+
+@Composable
+private fun ShowQrCode(
+    uri: String,
+    onDismiss: () -> Unit
+) {
+    Column(
+        modifier = Modifier.padding(16.dp),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        val qrCodeBitmap = remember { generateQrCode(uri) }
+        Text(
+            text = "Present QR code to mdoc reader",
+            style = MaterialTheme.typography.titleMedium.copy(
+                fontWeight = FontWeight.SemiBold
+            )
+        )
+
+        Spacer(Modifier.height(16.dp))
+
+        Image(
+            modifier = Modifier.fillMaxWidth(),
+            bitmap = qrCodeBitmap,
+            contentDescription = null,
+            contentScale = ContentScale.FillWidth
+        )
+
+        Spacer(Modifier.height(16.dp))
+
+        Button(
+            onClick = {
+                    onDismiss()
+            }
+        ) {
+            Text("Cancel")
+        }
+    }
+}

--- a/ComposeWallet/composeApp/src/commonMain/kotlin/org/multipaz/samples/wallet/cmp/ui/WalletDetailScreen.kt
+++ b/ComposeWallet/composeApp/src/commonMain/kotlin/org/multipaz/samples/wallet/cmp/ui/WalletDetailScreen.kt
@@ -1,0 +1,246 @@
+package org.multipaz.samples.wallet.cmp.ui
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.QrCode
+import androidx.compose.material.icons.outlined.Contactless
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import coil3.ImageLoader
+import kotlinx.coroutines.launch
+import org.multipaz.compose.document.DocumentInfo
+import org.multipaz.compose.document.DocumentModel
+import org.multipaz.compose.permissions.rememberBluetoothEnabledState
+import org.multipaz.compose.permissions.rememberBluetoothPermissionState
+import org.multipaz.documenttype.DocumentTypeRepository
+import org.multipaz.presentment.model.PresentmentModel
+import org.multipaz.presentment.model.PresentmentSource
+import org.multipaz.util.Logger
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun WalletDetailScreen(
+    documentInfo: DocumentInfo,
+    documentModel: DocumentModel,
+    presentmentModel: PresentmentModel,
+    presentmentSource: PresentmentSource,
+    documentTypeRepository: DocumentTypeRepository,
+    imageLoader: ImageLoader,
+    onBack: () -> Unit,
+) {
+    val coroutineScope = rememberCoroutineScope()
+    val blePermissionState = rememberBluetoothPermissionState()
+    val bleEnabledState = rememberBluetoothEnabledState()
+    var pendingQrRequest by remember { mutableStateOf(false) }
+    var showQrDialog by remember { mutableStateOf(false) }
+    var showBleInfoDialog by remember { mutableStateOf(false) }
+    var firstAttemptToEnableBle by remember { mutableStateOf(false) }
+    val documentInfo = documentModel.documentInfos
+        .collectAsState().value[documentInfo.document.identifier]
+
+    LaunchedEffect(
+        pendingQrRequest,
+        blePermissionState.isGranted,
+        bleEnabledState.isEnabled
+    ) {
+        Logger.d("permission", "${blePermissionState.isGranted}")
+        Logger.d("permissionEnables", "${bleEnabledState.isEnabled}")
+        if (pendingQrRequest && blePermissionState.isGranted && bleEnabledState.isEnabled) {
+            showQrDialog = true
+            pendingQrRequest = false
+        }
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = {  },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = null)
+                    }
+                },
+                actions = {
+                    IconButton(
+                        onClick = {
+
+                            coroutineScope.launch {
+                                when {
+                                    !blePermissionState.isGranted -> {
+                                        if (firstAttemptToEnableBle) {
+                                            showBleInfoDialog = true
+                                            if(pendingQrRequest) {
+                                                pendingQrRequest = false
+                                            }
+                                        } else {
+                                            pendingQrRequest = true
+                                            blePermissionState.launchPermissionRequest()
+                                            firstAttemptToEnableBle = true
+                                        }
+
+                                    }
+
+                                    !bleEnabledState.isEnabled -> {
+                                        pendingQrRequest = true
+                                        bleEnabledState.enable()
+                                        firstAttemptToEnableBle = true
+                                    }
+
+                                    else -> {
+                                        showQrDialog = true
+                                    }
+                                }
+                            }
+                        }
+                    ) {
+                        Icon(Icons.Filled.QrCode, contentDescription = "Present")
+                    }
+                }
+            )
+        }
+    ) { padding ->
+        documentInfo?.let { info ->
+            Column(
+                modifier = Modifier
+                    .padding(padding)
+                    .fillMaxSize(),
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                Spacer(modifier = Modifier.height(12.dp))
+
+                DocumentCard(info)
+
+                Spacer(modifier = Modifier.height(12.dp))
+
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.Center,
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    Icon(
+                        imageVector = Icons.Outlined.Contactless,
+                        contentDescription = null,
+                        modifier = Modifier.size(25.dp),
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                    Spacer(Modifier.width(8.dp))
+                    Text(
+                        text = "Hold to reader",
+                        style = MaterialTheme.typography.bodyMedium.copy(
+                            fontWeight = FontWeight.Bold
+                        ),
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+
+                }
+
+                Spacer(modifier = Modifier.weight(1f))
+            }
+        }
+
+
+    }
+
+    if (showQrDialog) {
+        QrPresentmentDialog(
+            presentmentModel = presentmentModel,
+            presentmentSource = presentmentSource,
+            documentTypeRepository = documentTypeRepository,
+            imageLoader = imageLoader,
+            onDismiss = {
+                presentmentModel.reset()
+                showQrDialog = false
+            }
+        )
+    }
+    if (showBleInfoDialog) {
+        BleSettingsDialog(
+            onDismiss = { showBleInfoDialog = false }
+        )
+    }
+}
+
+@Composable
+fun DocumentCard(
+    documentInfo: DocumentInfo
+) {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp)
+            .aspectRatio(1.6f)
+            .clip(RoundedCornerShape(16.dp))
+    ) {
+        Image(
+            bitmap = documentInfo.cardArt,
+            contentDescription = null,
+            modifier = Modifier.fillMaxSize(),
+            contentScale = ContentScale.Crop
+        )
+    }
+}
+
+@Composable
+fun BleSettingsDialog(
+    onDismiss: () -> Unit
+) {
+   AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Bluetooth required") },
+        text = {
+            Text(
+                "To present your ID, enable Bluetooth permissions and Bluetooth access in Settings."
+            )
+        },
+        confirmButton = {
+            TextButton(
+                onClick = {
+
+                    onDismiss()
+                }
+            ) {
+                Text("OK")
+            }
+        },
+
+    )
+}
+
+
+
+

--- a/ComposeWallet/composeApp/src/commonMain/kotlin/org/multipaz/samples/wallet/cmp/ui/WalletScreen.kt
+++ b/ComposeWallet/composeApp/src/commonMain/kotlin/org/multipaz/samples/wallet/cmp/ui/WalletScreen.kt
@@ -1,0 +1,112 @@
+package org.multipaz.samples.wallet.cmp.ui
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.LocalContentColor
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.graphics.PathEffect
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import org.multipaz.compose.carousels.DocumentCarousel
+import org.multipaz.compose.document.DocumentInfo
+import org.multipaz.compose.document.DocumentModel
+
+@Composable
+fun WalletScreen(
+    documentModel: DocumentModel,
+    onDocumentSelected: (DocumentInfo) -> Unit,
+) {
+    Column(
+        modifier = Modifier.fillMaxSize(),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        DocumentCarousel(
+            modifier = Modifier.fillMaxWidth(),
+            documentModel = documentModel,
+            onDocumentClicked = { documentInfo ->
+                onDocumentSelected(documentInfo)
+            },
+            emptyDocumentContent = {
+                EmptyWalletState()
+            }
+        )
+    }
+}
+
+
+@Composable
+private fun EmptyWalletState() {
+    Box(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center
+    ) {
+        val outlineColor = LocalContentColor.current.copy(alpha = 0.35f)
+
+        Box(
+            modifier = Modifier
+                .offset(y = (-24).dp)
+                .fillMaxWidth(0.9f)
+                .aspectRatio(1.6f)
+                .drawBehind {
+                    val strokeWidth = 1.5.dp.toPx()
+                    val dashLength = 10.dp.toPx()
+                    val gapLength = 6.dp.toPx()
+
+                    drawRoundRect(
+                        color = outlineColor,
+                        cornerRadius = CornerRadius(28.dp.toPx()),
+                        style = Stroke(
+                            width = strokeWidth,
+                            pathEffect = PathEffect.dashPathEffect(
+                                floatArrayOf(dashLength, gapLength)
+                            )
+                        )
+                    )
+                }
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(horizontal = 32.dp),
+                verticalArrangement = Arrangement.Center,
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                Text(
+                    text = "No documents added yet",
+                    style = MaterialTheme.typography.titleMedium
+                )
+
+                Spacer(modifier = Modifier.height(6.dp))
+
+                Text(
+                    text = "Add a document from issuer.multipaz.org",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = LocalContentColor.current.copy(alpha = 0.7f),
+                    textAlign = TextAlign.Center
+                )
+            }
+        }
+    }
+}
+
+
+
+
+
+


### PR DESCRIPTION
- Added Document Carousel
- Refactored App such that user needs to visit issuer.multpaz.org to issue a document. 
- User then taps document to navigate to the wallet details screen. In there you enable BLE and scan QR code in the navigation bar.
Fixes #44 

https://github.com/user-attachments/assets/fd98372d-de62-4e55-bca5-dc75945a5bc6

