### PR TITLE
Add empty iOS entitlements file

### DIFF
--- a/MultipazCodelab/Holder/iosApp/iosApp/iosApp.entitlements
+++ b/MultipazCodelab/Holder/iosApp/iosApp/iosApp.entitlements
@@ -2,5 +2,9 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>com.apple.developer.associated-domains</key>
+	<array>
+		<string>applinks:apps.multipaz.org</string>
+	</array>
 </dict>
 </plist>


### PR DESCRIPTION
## Fixes/Addresses

Fixes https://github.com/openwallet-foundation/multipaz/issues/1526

## What does this PR do?

Include iosApp.entitlements file to the VCS

## Why are we making this change?

The IOS App does not compile because the file iosApp.entitlements is missing

## How was this tested?

<!-- Describe how you verified these changes work -->
- [x] Tested on Android
- [x] Tested on iOS

## Checklist

- [x] Code follows project style guidelines
- [x] Documentation updated (if needed)
- [x] No breaking changes (or breaking changes are documented)
