### PR TITLE
Added support for Document Info in Wallet

### DIFF
--- a/ComposeWallet/build.gradle.kts
+++ b/ComposeWallet/build.gradle.kts
@@ -6,4 +6,5 @@ plugins {
     alias(libs.plugins.composeMultiplatform) apply false
     alias(libs.plugins.composeCompiler) apply false
     alias(libs.plugins.kotlinMultiplatform) apply false
+    alias(libs.plugins.kotlinSerialization) apply false
 }

--- a/ComposeWallet/composeApp/build.gradle.kts
+++ b/ComposeWallet/composeApp/build.gradle.kts
@@ -7,6 +7,7 @@ plugins {
     alias(libs.plugins.androidApplication)
     alias(libs.plugins.composeMultiplatform)
     alias(libs.plugins.composeCompiler)
+    alias(libs.plugins.kotlinSerialization)
 }
 
 kotlin {
@@ -64,6 +65,8 @@ kotlin {
             implementation(libs.multipaz.dcapi)
             implementation(libs.multipaz.compose)
             implementation(libs.coil.compose)
+            implementation(libs.navigation.compose)
+            implementation(libs.kotlinx.serialization.json)
         }
         commonTest.dependencies {
             implementation(libs.kotlin.test)

--- a/ComposeWallet/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/ComposeWallet/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<resources>
+    <!-- Common -->
+    <string name="back">Back</string>
+    <string name="cancel">Cancel</string>
+    <string name="remove">Remove</string>
+    <string name="ok">OK</string>
+    <string name="initializing">Initializing...</string>
+    <string name="present">Present</string>
+    <string name="more_options">More options</string>
+    <string name="collapse">Collapse</string>
+    <string name="expand">Expand</string>
+
+    <!-- WalletScreen -->
+    <string name="no_documents_added">No documents added yet</string>
+    <string name="add_document_hint">Add a document from issuer.multipaz.org</string>
+
+    <!-- DocumentViewerScreen -->
+    <string name="hold_to_reader">Hold to reader</string>
+    <string name="bluetooth_required">Bluetooth required</string>
+    <string name="bluetooth_settings_message">To present your ID, enable Bluetooth permissions and Bluetooth access in Settings.</string>
+
+    <!-- DocumentDetailsScreen -->
+    <string name="view_and_manage_activity">View and manage activity</string>
+    <string name="activity_history_off">Activity history is off</string>
+    <string name="type_info">%1$s info</string>
+    <string name="how_to_use_id">How to use your ID</string>
+    <string name="type_website">%1$s website</string>
+    <string name="youre_in_control">You\u2019re in control</string>
+    <string name="id_info_share_message">ID info will only be shared when you decide to share it</string>
+    <string name="id_issuer_message">Your ID issuer decides what info is on your digital ID and may send you notifications. Contact them with any questions.</string>
+    <string name="remove_digital_id_title">Remove digital ID?</string>
+    <string name="remove_digital_id_message">Your ID will be removed from your wallet and if you want to add it again, you\u2019ll need to start the process from the beginning.</string>
+
+    <!-- DocumentClaimsScreen -->
+    <string name="id_usage_description">To use your ID, tap your phone to a reader or scan your QR code. This screen can\u2019t be shown to verify your identity. </string>
+    <string name="learn_more">Learn more</string>
+    <string name="certificate_info">Certificate info</string>
+    <string name="cert_signed_date">Certificate signed date</string>
+    <string name="cert_valid_from">Certificate valid from</string>
+    <string name="cert_valid_until">Certificate valid until</string>
+    <string name="cert_expected_update">Certificate expected update</string>
+
+    <!-- QrPresentmentDialog -->
+    <string name="present_mdl">Present mDL</string>
+    <string name="show_qr_code">Show QR code</string>
+    <string name="present_qr_to_reader">Present QR code to mdoc reader</string>
+
+    <!-- ProvisioningScreen -->
+    <string name="cancel_provisioning">Cancel Provisioning</string>
+</resources>

--- a/ComposeWallet/composeApp/src/commonMain/kotlin/org/multipaz/samples/wallet/cmp/App.kt
+++ b/ComposeWallet/composeApp/src/commonMain/kotlin/org/multipaz/samples/wallet/cmp/App.kt
@@ -24,6 +24,8 @@ import kotlinx.coroutines.sync.withLock
 import kotlinx.io.bytestring.ByteString
 import mpzcmpwallet.composeapp.generated.resources.Res
 import mpzcmpwallet.composeapp.generated.resources.compose_multiplatform
+import mpzcmpwallet.composeapp.generated.resources.initializing
+import org.jetbrains.compose.resources.stringResource
 import org.multipaz.compose.document.DocumentModel
 import org.multipaz.compose.prompt.PromptDialogs
 import org.multipaz.crypto.X509Cert
@@ -34,7 +36,18 @@ import org.multipaz.document.DocumentMetadata
 import org.multipaz.document.DocumentStore
 import org.multipaz.document.buildDocumentStore
 import org.multipaz.documenttype.DocumentTypeRepository
+import org.multipaz.documenttype.knowntypes.AgeVerification
 import org.multipaz.documenttype.knowntypes.DrivingLicense
+import org.multipaz.documenttype.knowntypes.EUCertificateOfResidence
+import org.multipaz.documenttype.knowntypes.EUPersonalID
+import org.multipaz.documenttype.knowntypes.GermanPersonalID
+import org.multipaz.documenttype.knowntypes.IDPass
+import org.multipaz.documenttype.knowntypes.Loyalty
+import org.multipaz.documenttype.knowntypes.PhotoID
+import org.multipaz.documenttype.knowntypes.UtopiaMovieTicket
+import org.multipaz.documenttype.knowntypes.UtopiaNaturalization
+import org.multipaz.documenttype.knowntypes.VaccinationDocument
+import org.multipaz.documenttype.knowntypes.VehicleRegistration
 import org.multipaz.presentment.model.PresentmentModel
 import org.multipaz.presentment.model.PresentmentSource
 import org.multipaz.presentment.model.SimplePresentmentSource
@@ -86,6 +99,17 @@ class App() {
             secureAreaRepository = SecureAreaRepository.Builder().add(secureArea).build()
             documentTypeRepository = DocumentTypeRepository().apply {
                 addDocumentType(DrivingLicense.getDocumentType())
+                addDocumentType(EUPersonalID.getDocumentType())
+                addDocumentType(PhotoID.getDocumentType())
+                addDocumentType(AgeVerification.getDocumentType())
+                addDocumentType(EUCertificateOfResidence.getDocumentType())
+                addDocumentType(GermanPersonalID.getDocumentType())
+                addDocumentType(IDPass.getDocumentType())
+                addDocumentType(Loyalty.getDocumentType())
+                addDocumentType(VehicleRegistration.getDocumentType())
+                addDocumentType(VaccinationDocument.getDocumentType())
+                addDocumentType(UtopiaMovieTicket.getDocumentType())
+                addDocumentType(UtopiaNaturalization.getDocumentType())
             }
             documentStore = buildDocumentStore(storage = storage, secureAreaRepository = secureAreaRepository) {}
             documentModel = DocumentModel(documentStore = documentStore)
@@ -170,7 +194,7 @@ class App() {
                     verticalArrangement = Arrangement.Center,
                     horizontalAlignment = Alignment.CenterHorizontally
                 ) {
-                    Text("Initializing...")
+                    Text(stringResource(Res.string.initializing))
                 }
             }
             return

--- a/ComposeWallet/composeApp/src/commonMain/kotlin/org/multipaz/samples/wallet/cmp/Route.kt
+++ b/ComposeWallet/composeApp/src/commonMain/kotlin/org/multipaz/samples/wallet/cmp/Route.kt
@@ -1,14 +1,27 @@
 package org.multipaz.samples.wallet.cmp
 
-import org.multipaz.compose.document.DocumentInfo
+import kotlinx.serialization.Serializable
 
+@Serializable
 sealed interface AppRoute {
+    @Serializable
     data object Wallet : AppRoute
+
+    @Serializable
     data object Provisioning : AppRoute
 }
 
+@Serializable
 sealed interface WalletRoute {
-    data object Wallet : WalletRoute
-    data class WalletDetails(val documentInfo: DocumentInfo) : WalletRoute
-}
+    @Serializable
+    data object WalletList : WalletRoute
 
+    @Serializable
+    data class WalletDetails(val documentId: String) : WalletRoute
+
+    @Serializable
+    data class DocumentDetails(val documentId: String) : WalletRoute
+
+    @Serializable
+    data class PersonalIdInfo(val documentId: String) : WalletRoute
+}

--- a/ComposeWallet/composeApp/src/commonMain/kotlin/org/multipaz/samples/wallet/cmp/navhost/AppNavHost.kt
+++ b/ComposeWallet/composeApp/src/commonMain/kotlin/org/multipaz/samples/wallet/cmp/navhost/AppNavHost.kt
@@ -4,9 +4,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
 import coil3.ImageLoader
 import org.multipaz.provisioning.ProvisioningModel
 import org.multipaz.samples.wallet.cmp.App
@@ -18,30 +18,47 @@ fun AppNavHost(
     app: App,
     imageLoader: ImageLoader,
 ) {
-    var appRoute by remember { mutableStateOf<AppRoute>(AppRoute.Wallet) }
-    val provisioningState = app.provisioningModel.state.collectAsState().value
+    val navController = rememberNavController()
+    val provisioningState by app.provisioningModel.state.collectAsState()
 
     LaunchedEffect(provisioningState) {
         val provisioningActive =
             provisioningState != ProvisioningModel.Idle &&
-                    provisioningState != ProvisioningModel.CredentialsIssued
+                provisioningState != ProvisioningModel.CredentialsIssued
 
-        appRoute = if (provisioningActive) AppRoute.Provisioning else AppRoute.Wallet
+        val targetRoute: AppRoute = if (provisioningActive) {
+            AppRoute.Provisioning
+        } else {
+            AppRoute.Wallet
+        }
+
+        navController.navigate(targetRoute) {
+            popUpTo(0) { inclusive = true }
+            launchSingleTop = true
+        }
     }
 
-    when (appRoute) {
-        AppRoute.Wallet -> WalletNavHost(
-            documentModel = app.documentModel,
-            presentmentModel = app.presentmentModel,
-            presentmentSource = app.presentmentSource,
-            documentTypeRepository = app.documentTypeRepository,
-            imageLoader = imageLoader
-        )
+    NavHost(
+        navController = navController,
+        startDestination = AppRoute.Wallet,
+    ) {
+        composable<AppRoute.Wallet> {
+            WalletNavHost(
+                documentModel = app.documentModel,
+                presentmentModel = app.presentmentModel,
+                presentmentSource = app.presentmentSource,
+                documentTypeRepository = app.documentTypeRepository,
+                documentStore = app.documentStore,
+                imageLoader = imageLoader,
+            )
+        }
 
-        AppRoute.Provisioning -> ProvisioningScreen(
-            provisioningModel = app.provisioningModel,
-            provisioningSupport = app.provisioningSupport,
-            onCancel = { app.provisioningModel.cancel() }
-        )
+        composable<AppRoute.Provisioning> {
+            ProvisioningScreen(
+                provisioningModel = app.provisioningModel,
+                provisioningSupport = app.provisioningSupport,
+                onCancel = { app.provisioningModel.cancel() }
+            )
+        }
     }
 }

--- a/ComposeWallet/composeApp/src/commonMain/kotlin/org/multipaz/samples/wallet/cmp/navhost/WalletNavHost.kt
+++ b/ComposeWallet/composeApp/src/commonMain/kotlin/org/multipaz/samples/wallet/cmp/navhost/WalletNavHost.kt
@@ -1,15 +1,22 @@
 package org.multipaz.samples.wallet.cmp.navhost
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
+import androidx.navigation.toRoute
 import coil3.ImageLoader
+import kotlinx.coroutines.launch
 import org.multipaz.compose.document.DocumentModel
+import org.multipaz.document.DocumentStore
 import org.multipaz.documenttype.DocumentTypeRepository
 import org.multipaz.presentment.model.PresentmentModel
 import org.multipaz.presentment.model.PresentmentSource
 import org.multipaz.samples.wallet.cmp.WalletRoute
-import org.multipaz.samples.wallet.cmp.ui.WalletDetailScreen
+import org.multipaz.samples.wallet.cmp.ui.DocumentDetailsScreen
+import org.multipaz.samples.wallet.cmp.ui.DocumentClaimsScreen
+import org.multipaz.samples.wallet.cmp.ui.DocumentViewerScreen
 import org.multipaz.samples.wallet.cmp.ui.WalletScreen
 
 @Composable
@@ -18,29 +25,77 @@ fun WalletNavHost(
     presentmentModel: PresentmentModel,
     presentmentSource: PresentmentSource,
     documentTypeRepository: DocumentTypeRepository,
+    documentStore: DocumentStore,
     imageLoader: ImageLoader,
 ) {
-    val navState = remember { mutableStateOf<WalletRoute>(WalletRoute.Wallet) }
+    val navController = rememberNavController()
+    val coroutineScope = rememberCoroutineScope()
 
-    when (val route = navState.value) {
-        WalletRoute.Wallet -> {
+    NavHost(
+        navController = navController,
+        startDestination = WalletRoute.WalletList,
+    ) {
+        composable<WalletRoute.WalletList> {
             WalletScreen(
                 documentModel = documentModel,
                 onDocumentSelected = { documentInfo ->
-                    navState.value = WalletRoute.WalletDetails(documentInfo)
+                    navController.navigate(
+                        WalletRoute.WalletDetails(
+                            documentId = documentInfo.document.identifier
+                        )
+                    )
                 }
             )
         }
 
-        is WalletRoute.WalletDetails -> {
-            WalletDetailScreen(
-                documentInfo = route.documentInfo,
+        composable<WalletRoute.WalletDetails> { backStackEntry ->
+            val route = backStackEntry.toRoute<WalletRoute.WalletDetails>()
+            DocumentViewerScreen(
+                documentId = route.documentId,
                 documentModel = documentModel,
                 presentmentModel = presentmentModel,
                 presentmentSource = presentmentSource,
                 documentTypeRepository = documentTypeRepository,
                 imageLoader = imageLoader,
-                onBack = { navState.value = WalletRoute.Wallet }
+                onBack = { navController.popBackStack() },
+                onMenuClick = {
+                    navController.navigate(
+                        WalletRoute.DocumentDetails(documentId = route.documentId)
+                    )
+                }
+            )
+        }
+
+        composable<WalletRoute.PersonalIdInfo> { backStackEntry ->
+            val route = backStackEntry.toRoute<WalletRoute.PersonalIdInfo>()
+            DocumentClaimsScreen(
+                documentId = route.documentId,
+                documentModel = documentModel,
+                documentTypeRepository = documentTypeRepository,
+                onBack = { navController.popBackStack() }
+            )
+        }
+
+        composable<WalletRoute.DocumentDetails> { backStackEntry ->
+            val route = backStackEntry.toRoute<WalletRoute.DocumentDetails>()
+            DocumentDetailsScreen(
+                documentId = route.documentId,
+                documentModel = documentModel,
+                onBack = { navController.popBackStack() },
+                onPersonalIdInfoClick = {
+                    navController.navigate(
+                        WalletRoute.PersonalIdInfo(documentId = route.documentId)
+                    )
+                },
+                onRemove = {
+                    coroutineScope.launch {
+                        documentStore.deleteDocument(route.documentId)
+                        navController.popBackStack(
+                            route = WalletRoute.WalletList,
+                            inclusive = false
+                        )
+                    }
+                }
             )
         }
     }

--- a/ComposeWallet/composeApp/src/commonMain/kotlin/org/multipaz/samples/wallet/cmp/ui/DocumentClaimsScreen.kt
+++ b/ComposeWallet/composeApp/src/commonMain/kotlin/org/multipaz/samples/wallet/cmp/ui/DocumentClaimsScreen.kt
@@ -1,0 +1,305 @@
+package org.multipaz.samples.wallet.cmp.ui
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.KeyboardArrowDown
+import androidx.compose.material.icons.filled.KeyboardArrowUp
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.text.withStyle
+import androidx.compose.ui.unit.dp
+import kotlinx.datetime.TimeZone
+import mpzcmpwallet.composeapp.generated.resources.Res
+import mpzcmpwallet.composeapp.generated.resources.back
+import mpzcmpwallet.composeapp.generated.resources.cert_expected_update
+import mpzcmpwallet.composeapp.generated.resources.cert_signed_date
+import mpzcmpwallet.composeapp.generated.resources.cert_valid_from
+import mpzcmpwallet.composeapp.generated.resources.cert_valid_until
+import mpzcmpwallet.composeapp.generated.resources.certificate_info
+import mpzcmpwallet.composeapp.generated.resources.collapse
+import mpzcmpwallet.composeapp.generated.resources.expand
+import mpzcmpwallet.composeapp.generated.resources.id_usage_description
+import mpzcmpwallet.composeapp.generated.resources.learn_more
+import mpzcmpwallet.composeapp.generated.resources.type_info
+import org.jetbrains.compose.resources.stringResource
+import kotlinx.datetime.toLocalDateTime
+import kotlin.time.Instant
+import org.multipaz.cbor.Bstr
+import org.multipaz.claim.Claim
+import org.multipaz.claim.MdocClaim
+import org.multipaz.compose.claim.RenderClaimValue
+import org.multipaz.compose.document.DocumentModel
+import org.multipaz.documenttype.DocumentAttribute
+import org.multipaz.documenttype.DocumentAttributeType
+import org.multipaz.documenttype.DocumentTypeRepository
+import org.multipaz.mdoc.credential.MdocCredential
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun DocumentClaimsScreen(
+    documentId: String,
+    documentModel: DocumentModel,
+    documentTypeRepository: DocumentTypeRepository,
+    onBack: () -> Unit,
+) {
+    val documentInfo = documentModel.documentInfos.collectAsState().value[documentId]
+    var claims by remember { mutableStateOf<List<Claim>>(emptyList()) }
+    var certSignedDate by remember { mutableStateOf<Instant?>(null) }
+    var certValidFrom by remember { mutableStateOf<Instant?>(null) }
+    var certValidUntil by remember { mutableStateOf<Instant?>(null) }
+    var certExpectedUpdate by remember { mutableStateOf<Instant?>(null) }
+    var certInfoExpanded by remember { mutableStateOf(true) }
+
+    LaunchedEffect(documentId) {
+        val document = documentInfo?.document ?: return@LaunchedEffect
+        val credentials = document.getCertifiedCredentials()
+        val credential = credentials.firstOrNull() ?: return@LaunchedEffect
+        claims = credential.getClaims(documentTypeRepository)
+        if (credential is MdocCredential) {
+            val mso = credential.mso
+            certSignedDate = mso.signedAt
+            certValidFrom = mso.validFrom
+            certValidUntil = mso.validUntil
+            certExpectedUpdate = mso.expectedUpdate
+        }
+    }
+
+    val typeDisplayName = documentInfo?.document?.metadata?.typeDisplayName.orEmpty()
+
+    Scaffold(
+        containerColor = MaterialTheme.colorScheme.surface,
+        topBar = {
+            TopAppBar(
+                title = { },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = stringResource(Res.string.back))
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = MaterialTheme.colorScheme.errorContainer
+                )
+            )
+        }
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .padding(padding)
+                .fillMaxSize()
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = 16.dp)
+        ) {
+            Spacer(modifier = Modifier.height(24.dp))
+
+            documentInfo?.let { info ->
+                Image(
+                    bitmap = info.cardArt,
+                    contentDescription = typeDisplayName,
+                    modifier = Modifier
+                        .size(width = 100.dp, height = 63.dp)
+                        .clip(RoundedCornerShape(8.dp)),
+                    contentScale = ContentScale.Crop
+                )
+            }
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            Text(
+                text = stringResource(Res.string.type_info, typeDisplayName),
+                style = MaterialTheme.typography.headlineMedium
+            )
+
+            Spacer(modifier = Modifier.height(12.dp))
+
+            Text(
+                text = buildAnnotatedString {
+                    append(stringResource(Res.string.id_usage_description))
+                    withStyle(SpanStyle(textDecoration = TextDecoration.Underline)) {
+                        append(stringResource(Res.string.learn_more))
+                    }
+                },
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+
+            Spacer(modifier = Modifier.height(24.dp))
+
+            val allPictureClaims = claims.filter { it.isPictureClaim() }
+            var picturesRendered = false
+
+            var i = 0
+            while (i < claims.size) {
+                val claim = claims[i]
+                val isPicture = claim.isPictureClaim()
+                val isComplexType = claim.attribute?.type == DocumentAttributeType.ComplexType
+
+                if (isPicture) {
+                    if (!picturesRendered) {
+                        Row(
+                            horizontalArrangement = Arrangement.Start
+                        ) {
+                            allPictureClaims.forEach { picClaim ->
+                                RenderClaimValue(
+                                    claim = picClaim.withPictureAttribute(),
+                                    imageSize = 120.dp,
+                                    modifier = Modifier.width(150.dp)
+                                )
+                            }
+                        }
+                        Spacer(modifier = Modifier.height(24.dp))
+                        picturesRendered = true
+                    }
+                } else if (isComplexType) {
+                    Text(
+                        text = claim.displayName,
+                        style = MaterialTheme.typography.labelLarge,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                    Spacer(modifier = Modifier.height(16.dp))
+                } else {
+                    Text(
+                        text = claim.displayName,
+                        style = MaterialTheme.typography.titleMedium,
+                        color = MaterialTheme.colorScheme.onSurface
+                    )
+                    Spacer(modifier = Modifier.height(2.dp))
+                    RenderClaimValue(claim = claim)
+                    Spacer(modifier = Modifier.height(24.dp))
+                }
+                i++
+            }
+
+            if (certSignedDate != null) {
+                Spacer(modifier = Modifier.height(16.dp))
+                Surface(
+                    shape = RoundedCornerShape(16.dp),
+                    color = MaterialTheme.colorScheme.errorContainer,
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    Column {
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .clickable { certInfoExpanded = !certInfoExpanded }
+                                .padding(16.dp),
+                            horizontalArrangement = Arrangement.SpaceBetween,
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            Text(
+                                text = stringResource(Res.string.certificate_info),
+                                style = MaterialTheme.typography.titleMedium
+                            )
+                            Icon(
+                                imageVector = if (certInfoExpanded)
+                                    Icons.Filled.KeyboardArrowUp
+                                else
+                                    Icons.Filled.KeyboardArrowDown,
+                                contentDescription = if (certInfoExpanded) stringResource(Res.string.collapse) else stringResource(Res.string.expand)
+                            )
+                        }
+                        AnimatedVisibility(visible = certInfoExpanded) {
+                            Column(
+                                modifier = Modifier.padding(
+                                    start = 16.dp,
+                                    end = 16.dp,
+                                    bottom = 16.dp
+                                )
+                            ) {
+                                CertificateInfoItem(stringResource(Res.string.cert_signed_date), certSignedDate)
+                                CertificateInfoItem(stringResource(Res.string.cert_valid_from), certValidFrom)
+                                CertificateInfoItem(stringResource(Res.string.cert_valid_until), certValidUntil)
+                                CertificateInfoItem(stringResource(Res.string.cert_expected_update), certExpectedUpdate)
+                            }
+                        }
+                    }
+                }
+            }
+
+            Spacer(modifier = Modifier.height(32.dp))
+        }
+    }
+}
+
+@Composable
+private fun CertificateInfoItem(label: String, instant: Instant?) {
+    if (instant == null) return
+    val dt = instant.toLocalDateTime(TimeZone.UTC)
+    val months = listOf(
+        "Jan", "Feb", "Mar", "Apr", "May", "Jun",
+        "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"
+    )
+    val formatted = "${months[dt.month.ordinal]} ${dt.day}, ${dt.year}"
+    Text(
+        text = label,
+        style = MaterialTheme.typography.titleMedium
+    )
+    Text(
+        text = formatted,
+        style = MaterialTheme.typography.bodyMedium,
+        color = MaterialTheme.colorScheme.onSurfaceVariant
+    )
+    Spacer(modifier = Modifier.height(8.dp))
+}
+
+private fun Claim.isPictureClaim(): Boolean {
+    if (attribute?.type == DocumentAttributeType.Picture) return true
+    if (this is MdocClaim && value is Bstr && value.asBstr.size > 100) return true
+    return false
+}
+
+private fun Claim.withPictureAttribute(): Claim {
+    if (attribute?.type == DocumentAttributeType.Picture) return this
+    if (this is MdocClaim) {
+        return copy(
+            attribute = DocumentAttribute(
+                type = DocumentAttributeType.Picture,
+                identifier = dataElementName,
+                displayName = displayName,
+                description = "",
+                icon = null,
+                sampleValueMdoc = null,
+                sampleValueJson = null,
+                parentAttribute = null,
+                embeddedAttributes = emptyList()
+            )
+        )
+    }
+    return this
+}

--- a/ComposeWallet/composeApp/src/commonMain/kotlin/org/multipaz/samples/wallet/cmp/ui/DocumentDetailsScreen.kt
+++ b/ComposeWallet/composeApp/src/commonMain/kotlin/org/multipaz/samples/wallet/cmp/ui/DocumentDetailsScreen.kt
@@ -1,0 +1,268 @@
+package org.multipaz.samples.wallet.cmp.ui
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.outlined.HelpOutline
+import androidx.compose.material.icons.outlined.Badge
+import androidx.compose.material.icons.outlined.Delete
+import androidx.compose.material.icons.outlined.History
+import androidx.compose.material.icons.outlined.Language
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.unit.dp
+import mpzcmpwallet.composeapp.generated.resources.Res
+import mpzcmpwallet.composeapp.generated.resources.activity_history_off
+import mpzcmpwallet.composeapp.generated.resources.back
+import mpzcmpwallet.composeapp.generated.resources.cancel
+import mpzcmpwallet.composeapp.generated.resources.how_to_use_id
+import mpzcmpwallet.composeapp.generated.resources.id_info_share_message
+import mpzcmpwallet.composeapp.generated.resources.id_issuer_message
+import mpzcmpwallet.composeapp.generated.resources.remove
+import mpzcmpwallet.composeapp.generated.resources.remove_digital_id_message
+import mpzcmpwallet.composeapp.generated.resources.remove_digital_id_title
+import mpzcmpwallet.composeapp.generated.resources.type_info
+import mpzcmpwallet.composeapp.generated.resources.type_website
+import mpzcmpwallet.composeapp.generated.resources.view_and_manage_activity
+import mpzcmpwallet.composeapp.generated.resources.youre_in_control
+import org.jetbrains.compose.resources.stringResource
+import org.multipaz.compose.document.DocumentModel
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun DocumentDetailsScreen(
+    documentId: String,
+    documentModel: DocumentModel,
+    onBack: () -> Unit,
+    onPersonalIdInfoClick: () -> Unit,
+    onRemove: () -> Unit,
+) {
+    val documentInfo = documentModel.documentInfos
+        .collectAsState().value[documentId]
+    var showRemoveDialog by remember { mutableStateOf(false) }
+
+    if (showRemoveDialog) {
+        AlertDialog(
+            onDismissRequest = { showRemoveDialog = false },
+            title = {
+                Text(
+                    text = stringResource(Res.string.remove_digital_id_title),
+                    style = MaterialTheme.typography.headlineSmall
+                )
+            },
+            text = {
+                Text(
+                    text = stringResource(Res.string.remove_digital_id_message),
+                    style = MaterialTheme.typography.bodyMedium
+                )
+            },
+            confirmButton = {
+                TextButton(onClick = {
+                    showRemoveDialog = false
+                    onRemove()
+                }) {
+                    Text(stringResource(Res.string.remove))
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showRemoveDialog = false }) {
+                    Text(stringResource(Res.string.cancel))
+                }
+            }
+        )
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = stringResource(Res.string.back))
+                    }
+                }
+            )
+        }
+    ) { padding ->
+        documentInfo?.let { info ->
+            val displayName = info.document.metadata.displayName.orEmpty()
+            val typeDisplayName = info.document.metadata.typeDisplayName.orEmpty()
+
+            Column(
+                modifier = Modifier
+                    .padding(padding)
+                    .fillMaxSize()
+                    .verticalScroll(rememberScrollState())
+                    .padding(horizontal = 16.dp)
+            ) {
+                Image(
+                    bitmap = info.cardArt,
+                    contentDescription = typeDisplayName,
+                    modifier = Modifier
+                        .size(width = 100.dp, height = 63.dp)
+                        .clip(RoundedCornerShape(8.dp)),
+                    contentScale = ContentScale.Crop
+                )
+
+                Spacer(modifier = Modifier.height(8.dp))
+
+                Text(
+                    text = typeDisplayName.ifEmpty { displayName },
+                    style = MaterialTheme.typography.headlineMedium
+                )
+
+                Spacer(modifier = Modifier.height(24.dp))
+
+                DetailMenuItem(
+                    icon = { Icon(Icons.Outlined.History, contentDescription = null) },
+                    title = stringResource(Res.string.view_and_manage_activity),
+                    subtitle = stringResource(Res.string.activity_history_off),
+                    onClick = { }
+                )
+
+                DetailMenuItem(
+                    icon = { Icon(Icons.Outlined.Badge, contentDescription = null) },
+                    title = stringResource(Res.string.type_info, typeDisplayName),
+                    onClick = onPersonalIdInfoClick
+                )
+
+                DetailMenuItem(
+                    icon = {
+                        Icon(
+                            Icons.AutoMirrored.Outlined.HelpOutline,
+                            contentDescription = null
+                        )
+                    },
+                    title = stringResource(Res.string.how_to_use_id),
+                    onClick = { }
+                )
+
+                DetailMenuItem(
+                    icon = { Icon(Icons.Outlined.Language, contentDescription = null) },
+                    title = stringResource(Res.string.type_website, typeDisplayName),
+                    onClick = { }
+                )
+
+                Spacer(modifier = Modifier.height(24.dp))
+
+                Text(
+                    text = stringResource(Res.string.youre_in_control),
+                    style = MaterialTheme.typography.titleMedium
+                )
+
+                Spacer(modifier = Modifier.height(4.dp))
+
+                Text(
+                    text = stringResource(Res.string.id_info_share_message),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+
+                Spacer(modifier = Modifier.height(24.dp))
+
+                Surface(
+                    onClick = { showRemoveDialog = true },
+                    shape = RoundedCornerShape(16.dp),
+                    color = MaterialTheme.colorScheme.errorContainer,
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    Row(
+                        modifier = Modifier.padding(16.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Icon(
+                            Icons.Outlined.Delete,
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.onErrorContainer
+                        )
+                        Spacer(modifier = Modifier.width(16.dp))
+                        Text(
+                            text = stringResource(Res.string.remove),
+                            style = MaterialTheme.typography.bodyLarge,
+                            color = MaterialTheme.colorScheme.onErrorContainer
+                        )
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(24.dp))
+
+                Text(
+                    text = stringResource(Res.string.id_issuer_message),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+
+                Spacer(modifier = Modifier.height(32.dp))
+            }
+        }
+    }
+}
+
+@Composable
+private fun DetailMenuItem(
+    icon: @Composable () -> Unit,
+    title: String,
+    subtitle: String? = null,
+    onClick: () -> Unit,
+) {
+    Surface(
+        onClick = onClick,
+        shape = RoundedCornerShape(16.dp),
+        color = MaterialTheme.colorScheme.surfaceContainerLow,
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 4.dp)
+    ) {
+        Row(
+            modifier = Modifier.padding(16.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            icon()
+            Spacer(modifier = Modifier.width(16.dp))
+            Column(verticalArrangement = Arrangement.Center) {
+                Text(
+                    text = title,
+                    style = MaterialTheme.typography.bodyLarge
+                )
+                if (subtitle != null) {
+                    Text(
+                        text = subtitle,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            }
+        }
+    }
+}

--- a/ComposeWallet/composeApp/src/commonMain/kotlin/org/multipaz/samples/wallet/cmp/ui/DocumentViewerScreen.kt
+++ b/ComposeWallet/composeApp/src/commonMain/kotlin/org/multipaz/samples/wallet/cmp/ui/DocumentViewerScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.QrCode
 import androidx.compose.material.icons.outlined.Contactless
 import androidx.compose.material3.AlertDialog
@@ -42,6 +43,14 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import coil3.ImageLoader
+import mpzcmpwallet.composeapp.generated.resources.Res
+import mpzcmpwallet.composeapp.generated.resources.bluetooth_required
+import mpzcmpwallet.composeapp.generated.resources.bluetooth_settings_message
+import mpzcmpwallet.composeapp.generated.resources.hold_to_reader
+import mpzcmpwallet.composeapp.generated.resources.more_options
+import mpzcmpwallet.composeapp.generated.resources.ok
+import mpzcmpwallet.composeapp.generated.resources.present
+import org.jetbrains.compose.resources.stringResource
 import kotlinx.coroutines.launch
 import org.multipaz.compose.document.DocumentInfo
 import org.multipaz.compose.document.DocumentModel
@@ -54,14 +63,15 @@ import org.multipaz.util.Logger
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun WalletDetailScreen(
-    documentInfo: DocumentInfo,
+fun DocumentViewerScreen(
+    documentId: String,
     documentModel: DocumentModel,
     presentmentModel: PresentmentModel,
     presentmentSource: PresentmentSource,
     documentTypeRepository: DocumentTypeRepository,
     imageLoader: ImageLoader,
     onBack: () -> Unit,
+    onMenuClick: () -> Unit,
 ) {
     val coroutineScope = rememberCoroutineScope()
     val blePermissionState = rememberBluetoothPermissionState()
@@ -71,7 +81,7 @@ fun WalletDetailScreen(
     var showBleInfoDialog by remember { mutableStateOf(false) }
     var firstAttemptToEnableBle by remember { mutableStateOf(false) }
     val documentInfo = documentModel.documentInfos
-        .collectAsState().value[documentInfo.document.identifier]
+        .collectAsState().value[documentId]
 
     LaunchedEffect(
         pendingQrRequest,
@@ -128,7 +138,10 @@ fun WalletDetailScreen(
                             }
                         }
                     ) {
-                        Icon(Icons.Filled.QrCode, contentDescription = "Present")
+                        Icon(Icons.Filled.QrCode, contentDescription = stringResource(Res.string.present))
+                    }
+                    IconButton(onClick = onMenuClick) {
+                        Icon(Icons.Filled.MoreVert, contentDescription = stringResource(Res.string.more_options))
                     }
                 }
             )
@@ -160,7 +173,7 @@ fun WalletDetailScreen(
                     )
                     Spacer(Modifier.width(8.dp))
                     Text(
-                        text = "Hold to reader",
+                        text = stringResource(Res.string.hold_to_reader),
                         style = MaterialTheme.typography.bodyMedium.copy(
                             fontWeight = FontWeight.Bold
                         ),
@@ -221,11 +234,9 @@ fun BleSettingsDialog(
 ) {
    AlertDialog(
         onDismissRequest = onDismiss,
-        title = { Text("Bluetooth required") },
+        title = { Text(stringResource(Res.string.bluetooth_required)) },
         text = {
-            Text(
-                "To present your ID, enable Bluetooth permissions and Bluetooth access in Settings."
-            )
+            Text(stringResource(Res.string.bluetooth_settings_message))
         },
         confirmButton = {
             TextButton(
@@ -234,7 +245,7 @@ fun BleSettingsDialog(
                     onDismiss()
                 }
             ) {
-                Text("OK")
+                Text(stringResource(Res.string.ok))
             }
         },
 

--- a/ComposeWallet/composeApp/src/commonMain/kotlin/org/multipaz/samples/wallet/cmp/ui/ProvisioningScreen.kt
+++ b/ComposeWallet/composeApp/src/commonMain/kotlin/org/multipaz/samples/wallet/cmp/ui/ProvisioningScreen.kt
@@ -11,6 +11,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import mpzcmpwallet.composeapp.generated.resources.Res
+import mpzcmpwallet.composeapp.generated.resources.cancel_provisioning
+import org.jetbrains.compose.resources.stringResource
 import org.multipaz.compose.provisioning.Provisioning
 import org.multipaz.provisioning.ProvisioningModel
 import org.multipaz.samples.wallet.cmp.ProvisioningSupport
@@ -36,7 +39,7 @@ fun ProvisioningScreen(
         Spacer(Modifier.padding(12.dp))
 
         Button(onClick = onCancel) {
-            Text("Cancel Provisioning")
+            Text(stringResource(Res.string.cancel_provisioning))
         }
     }
 }

--- a/ComposeWallet/composeApp/src/commonMain/kotlin/org/multipaz/samples/wallet/cmp/ui/QrPresentmentDialog.kt
+++ b/ComposeWallet/composeApp/src/commonMain/kotlin/org/multipaz/samples/wallet/cmp/ui/QrPresentmentDialog.kt
@@ -22,8 +22,13 @@ import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import coil3.ImageLoader
 import mpzcmpwallet.composeapp.generated.resources.Res
+import mpzcmpwallet.composeapp.generated.resources.cancel
 import mpzcmpwallet.composeapp.generated.resources.compose_multiplatform
+import mpzcmpwallet.composeapp.generated.resources.present_mdl
+import mpzcmpwallet.composeapp.generated.resources.present_qr_to_reader
+import mpzcmpwallet.composeapp.generated.resources.show_qr_code
 import org.jetbrains.compose.resources.painterResource
+import org.jetbrains.compose.resources.stringResource
 import org.multipaz.compose.presentment.MdocProximityQrPresentment
 import org.multipaz.compose.presentment.MdocProximityQrSettings
 import org.multipaz.compose.qrcode.generateQrCode
@@ -94,7 +99,7 @@ private fun ShowQrButton(
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
         Text(
-            text = "Present mDL",
+            text = stringResource(Res.string.present_mdl),
             style = MaterialTheme.typography.titleMedium
         )
         Spacer(Modifier.height(16.dp))
@@ -118,7 +123,7 @@ private fun ShowQrButton(
                 )
             }
         ) {
-            Text("Show QR code")
+            Text(stringResource(Res.string.show_qr_code))
         }
     }
 }
@@ -135,7 +140,7 @@ private fun ShowQrCode(
     ) {
         val qrCodeBitmap = remember { generateQrCode(uri) }
         Text(
-            text = "Present QR code to mdoc reader",
+            text = stringResource(Res.string.present_qr_to_reader),
             style = MaterialTheme.typography.titleMedium.copy(
                 fontWeight = FontWeight.SemiBold
             )
@@ -157,7 +162,7 @@ private fun ShowQrCode(
                     onDismiss()
             }
         ) {
-            Text("Cancel")
+            Text(stringResource(Res.string.cancel))
         }
     }
 }

--- a/ComposeWallet/composeApp/src/commonMain/kotlin/org/multipaz/samples/wallet/cmp/ui/WalletScreen.kt
+++ b/ComposeWallet/composeApp/src/commonMain/kotlin/org/multipaz/samples/wallet/cmp/ui/WalletScreen.kt
@@ -22,6 +22,10 @@ import androidx.compose.ui.graphics.PathEffect
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import mpzcmpwallet.composeapp.generated.resources.Res
+import mpzcmpwallet.composeapp.generated.resources.add_document_hint
+import mpzcmpwallet.composeapp.generated.resources.no_documents_added
+import org.jetbrains.compose.resources.stringResource
 import org.multipaz.compose.carousels.DocumentCarousel
 import org.multipaz.compose.document.DocumentInfo
 import org.multipaz.compose.document.DocumentModel
@@ -88,14 +92,14 @@ private fun EmptyWalletState() {
                 horizontalAlignment = Alignment.CenterHorizontally
             ) {
                 Text(
-                    text = "No documents added yet",
+                    text = stringResource(Res.string.no_documents_added),
                     style = MaterialTheme.typography.titleMedium
                 )
 
                 Spacer(modifier = Modifier.height(6.dp))
 
                 Text(
-                    text = "Add a document from issuer.multipaz.org",
+                    text = stringResource(Res.string.add_document_hint),
                     style = MaterialTheme.typography.bodyMedium,
                     color = LocalContentColor.current.copy(alpha = 0.7f),
                     textAlign = TextAlign.Center

--- a/ComposeWallet/gradle/libs.versions.toml
+++ b/ComposeWallet/gradle/libs.versions.toml
@@ -20,6 +20,7 @@ kotlinx-serialization = "1.9.0"
 coil = "3.3.0"
 multipaz = "0.96.0"
 ktor = "2.3.13"
+navigation-compose = "2.9.1"
 
 [libraries]
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
@@ -49,6 +50,7 @@ multipaz-compose = { group = "org.multipaz", name = "multipaz-compose", version.
 ktor-client-android = { module = "io.ktor:ktor-client-android", version.ref = "ktor" }
 ktor-client-darwin = { module = "io.ktor:ktor-client-darwin", version.ref = "ktor" }
 ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
+navigation-compose = { module = "org.jetbrains.androidx.navigation:navigation-compose", version.ref = "navigation-compose" }
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }
@@ -56,3 +58,4 @@ androidLibrary = { id = "com.android.library", version.ref = "agp" }
 composeMultiplatform = { id = "org.jetbrains.compose", version.ref = "composeMultiplatform" }
 composeCompiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 kotlinMultiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
+kotlinSerialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }


### PR DESCRIPTION
## Fixes/Addresses

Fixes/Addresses #67 

## What does this PR do?

- Added a DocumentClaimsScreen 
-  Added a DocumentDetailsScreen
- Added compose navigation 
- Added strings 

<!-- A brief description of the changes in this PR -->

## Why are we making this change?
This is feature iteration over the sample wallet app. Added two new feature which allows the user to access more information about their document and also delete document as well.

<!-- What problem does this solve? Provide context and background -->

## How was this tested?

<!-- Describe how you verified these changes work -->
- [x] Tested on Android
- [ ] Tested on iOS

## Screenshots/Videos (if applicable)

<!-- Add screenshots or videos to demonstrate the changes -->
| DocumentViewerScreen | DocumentDetailsScreen | DocumentClaimsScreen |
|--------|-------|-----------|
| <img width="1080" height="2424" alt="Screenshot_20260211_053228" src="https://github.com/user-attachments/assets/e0136d49-f3a6-4388-aa85-60615d092ec2" /> | <img width="1080" height="2424" alt="Screenshot_20260211_053240" src="https://github.com/user-attachments/assets/dd9cc862-f12b-470b-8d23-93d6f15f3833" />| <img width="1080" height="2424" alt="Screenshot_20260211_053253" src="https://github.com/user-attachments/assets/f2bb02bf-8252-4bbd-8e17-9474ceec96a0" />|

## Checklist

- [x] Code follows project style guidelines
- [x] Documentation updated (if needed)
- [x] No breaking changes (or breaking changes are documented)
