### PR TITLE
GetStartedSample ios issuance fix

### DIFF
--- a/MultipazGettingStartedSample/iosApp/iosApp/iosApp.entitlements
+++ b/MultipazGettingStartedSample/iosApp/iosApp/iosApp.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.associated-domains</key>
+	<array>
+		<string>applinks:apps.multipaz.org</string>
+	</array>
+</dict>
+</plist>


### PR DESCRIPTION
Fixes https://github.com/openwallet-foundation/multipaz/issues/1537

# What does this PR do?

Add iosApp.entitlements for GetStart sample (used for iOS OpenID4VCI enrollment).

# Why are we making this change?

iOS could not finish enrollment without this file; the associated-domains entitlement (applinks:apps.multipaz.org) is required for the OpenID4VCI enrollment flow.

# How was this tested?

- Tested on Android: N/A (entitlements are iOS-only)
- Tested on iOS: Follow https://developer.multipaz.org/docs/guides/facenet#ios-build to build the app, then run it and complete enrollment.

# Screenshots/Videos (if applicable)

N/A

# Checklist

- [x] Code follows project style guidelines
- [x] Documentation updated (if needed)
- [x] No breaking changes (or breaking changes are documented)